### PR TITLE
don't fail on error when running javadoc jar gradle tasks

### DIFF
--- a/gradle/maven_central.gradle
+++ b/gradle/maven_central.gradle
@@ -111,6 +111,7 @@ afterEvaluate { project ->
     }
 
     task androidJavadocs(type: Javadoc) {
+        failOnError false
         source = android.sourceSets.main.java.srcDirs
         classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
     }


### PR DESCRIPTION
a lot of documentation around this with no clear solution:
e.g.:
https://github.com/chrisbanes/gradle-mvn-push/issues/9
https://github.com/chrisbanes/gradle-mvn-push/pull/13