### PR TITLE
Adds missing milliseconds to result of WatchFaceTime#toMillis

### DIFF
--- a/ustwo-clockwise/src/main/java/com/ustwo/clockwise/common/WatchFaceTime.java
+++ b/ustwo-clockwise/src/main/java/com/ustwo/clockwise/common/WatchFaceTime.java
@@ -85,6 +85,11 @@ public class WatchFaceTime extends Time {
         this.millis = (int)(millis % 1000l);
     }
 
+    @Override
+    public long toMillis(boolean ignoreDst) {
+        return super.toMillis(ignoreDst) + millis;
+    }
+
     private void setHour12() {
         hour12 = (hour % 12);
     }


### PR DESCRIPTION
WatchFaceTime adds millisecond values which Time didn't have, but toMillis() had not
been overridden to add these to the result. Fixes issue #29.